### PR TITLE
Implement automatic user creation branch in go to match the current portal-conductor

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,13 @@
+name: golangci-lint
+on:
+  push:
+    branches:
+      - master
+      - main
+  pull_request:
+
+jobs:
+  call-workflow-passing-data:
+    uses: cyverse-de/github-workflows/.github/workflows/golangci-lint.yml@v0.2.5
+    with:
+      go-version: 1.26

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -8,6 +8,6 @@ on:
 
 jobs:
   call-workflow-passing-data:
-    uses: cyverse-de/github-workflows/.github/workflows/golangci-lint.yml@v0.2.5
+    uses: cyverse-de/github-workflows/.github/workflows/golangci-lint.yml@v0.3.1
     with:
       go-version: 1.26

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,13 @@
+name: Run Tests
+on:
+  push:
+    branches:
+      - master
+      - main
+  pull_request:
+
+jobs:
+  test:
+    uses: cyverse-de/github-workflows/.github/workflows/go-test.yml@v0.3.1
+    with:
+      go-version: 1.26

--- a/api/async_test.go
+++ b/api/async_test.go
@@ -93,7 +93,7 @@ func TestUsernameParamID(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			a := New(testConfig(), nil, nil, client, nil, nil, "app-123")
+			a := New(testConfig(), nil, nil, client, nil, nil, "app-123", nil)
 			id, err := a.usernameParamID(client, "de", "app-123")
 
 			if tt.wantError {

--- a/api/portalmgmt.go
+++ b/api/portalmgmt.go
@@ -273,8 +273,9 @@ func (a *API) createPortalUser(w http.ResponseWriter, r *http.Request) error {
 		GridInstitutionID: req.GridInstitutionID,
 		HasVerifiedEmail:  true, // SSO users arrive from a trusted IdP.
 	}
-	// emailVerified=true: the IdP has already validated ownership of this address.
-	userID, err := portaldb.CreateUserWithEmail(ctx, a.portalDB, userData, true)
+	// emailVerified is derived from HasVerifiedEmail — both fields are set
+	// together so they can't diverge.
+	userID, err := portaldb.CreateUserWithEmail(ctx, a.portalDB, userData)
 	if err != nil {
 		return fmt.Errorf("creating portal user: %w", err)
 	}

--- a/api/portalmgmt.go
+++ b/api/portalmgmt.go
@@ -252,7 +252,8 @@ func (a *API) createPortalUser(w http.ResponseWriter, r *http.Request) error {
 		occupationName = "Unknown"
 	}
 
-	// 1. Create user in portal database.
+	// 1. Create user and email address in the portal database atomically.
+	// If either insert fails, the transaction rolls back and no cleanup is needed.
 	log.Printf("Creating user in portal database: %s", req.Username)
 	userData := portaldb.CreateUserData{
 		Username:          req.Username,
@@ -272,19 +273,23 @@ func (a *API) createPortalUser(w http.ResponseWriter, r *http.Request) error {
 		GridInstitutionID: req.GridInstitutionID,
 		HasVerifiedEmail:  true, // SSO users arrive from a trusted IdP.
 	}
-	userID, err := portaldb.CreateUser(ctx, a.portalDB, userData)
+	// emailVerified=true: the IdP has already validated ownership of this address.
+	userID, err := portaldb.CreateUserWithEmail(ctx, a.portalDB, userData, true)
 	if err != nil {
 		return fmt.Errorf("creating portal user: %w", err)
 	}
 
-	// 2. Create email address record. Marked as verified because SSO users
-	// arrive from a trusted IdP that has already validated their email.
-	log.Printf("Creating email address record for user %d", userID)
-	if err := portaldb.CreateEmailAddress(ctx, a.portalDB, userID, req.Email, true, true); err != nil {
-		return fmt.Errorf("creating email address: %w", err)
+	// compensate rolls back the portal DB records if a downstream step fails,
+	// so that a retry with the same username/email can succeed.
+	compensate := func(cause error, step string) error {
+		log.Printf("Provisioning failed at %s for user %s: %v — removing portal DB records", step, req.Username, cause)
+		if delErr := portaldb.DeleteUserByID(ctx, a.portalDB, userID); delErr != nil {
+			log.Printf("WARNING: compensation failed for user %s (id=%d): %v — manual cleanup required", req.Username, userID, delErr)
+		}
+		return fmt.Errorf("%s: %w", step, cause)
 	}
 
-	// 3. Create user in LDAP with default groups.
+	// 2. Create user in LDAP with default groups.
 	uidNumber := userID + int64(a.cfg.Security.UIDNumberOffset)
 	log.Printf("Creating LDAP user: %s (uid: %d)", req.Username, uidNumber)
 
@@ -300,16 +305,16 @@ func (a *API) createPortalUser(w http.ResponseWriter, r *http.Request) error {
 		Title:        occupationName,
 	}
 	if err := a.ldap.CreateUserWithGroups(ldapUser, a.cfg.LDAP.EveryoneGroup, a.cfg.LDAP.CommunityGroup); err != nil {
-		return fmt.Errorf("creating LDAP user: %w", err)
+		return compensate(err, "creating LDAP user")
 	}
 
-	// 4. Create user in DataStore.
+	// 3. Create user in DataStore.
 	log.Printf("Creating DataStore user: %s", req.Username)
 	if err := a.ds.CreateUserWithPermissions(req.Username, password, a.cfg.IRODS.IPCServicesUser, a.cfg.IRODS.AdminUser); err != nil {
-		return fmt.Errorf("creating DataStore user: %w", err)
+		return compensate(err, "creating DataStore user")
 	}
 
-	// 5. Set job limits via Terrain (optional).
+	// 4. Set job limits via Terrain (optional).
 	if a.terrain != nil && req.JobLimit != nil {
 		log.Printf("Setting job limits for user: %s", req.Username)
 		if limitErr := a.terrain.SetConcurrentJobLimits(req.Username, *req.JobLimit); limitErr != nil {

--- a/api/portalmgmt.go
+++ b/api/portalmgmt.go
@@ -1,11 +1,13 @@
 package api
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/base64"
 	"fmt"
 	"log"
 	"net/http"
+	"net/mail"
 	"regexp"
 	"strconv"
 
@@ -19,6 +21,15 @@ var usernamePattern = regexp.MustCompile(`^[0-9a-z]+$`)
 // usernameValid checks whether a username matches the required format.
 func usernameValid(username string) bool {
 	return usernamePattern.MatchString(username)
+}
+
+// emailValid checks whether an email address has a valid format.
+func emailValid(email string) bool {
+	if email == "" {
+		return false
+	}
+	addr, err := mail.ParseAddress(email)
+	return err == nil && addr.Address == email
 }
 
 // generatePassword creates a cryptographically random password string.
@@ -212,6 +223,11 @@ func (a *API) createPortalUser(w http.ResponseWriter, r *http.Request) error {
 		return httpErrorf(http.StatusBadRequest, "Username format is invalid.")
 	}
 
+	// Validate email format.
+	if !emailValid(req.Email) {
+		return httpErrorf(http.StatusBadRequest, "Invalid email address format.")
+	}
+
 	// Check restricted.
 	isRestricted, err := portaldb.IsRestrictedUsername(ctx, a.portalDB, req.Username)
 	if err != nil {
@@ -286,12 +302,23 @@ func (a *API) createPortalUser(w http.ResponseWriter, r *http.Request) error {
 		return fmt.Errorf("creating portal user: %w", err)
 	}
 
-	// compensate rolls back the portal DB records if a downstream step fails,
+	// compensate rolls back completed steps if a downstream step fails,
 	// so that a retry with the same username/email can succeed.
+	// Use a context that won't be cancelled by client disconnect.
+	compensateCtx := context.WithoutCancel(ctx)
+	ldapCreated := false
+
 	compensate := func(cause error, step string) error {
-		log.Printf("Provisioning failed at %s for user %s: %v — removing portal DB records", step, req.Username, cause)
-		if delErr := portaldb.DeleteUserByID(ctx, a.portalDB, userID); delErr != nil {
-			log.Printf("WARNING: compensation failed for user %s (id=%d): %v — manual cleanup required", req.Username, userID, delErr)
+		log.Printf("Provisioning failed at %s for user %s: %v — rolling back completed steps", step, req.Username, cause)
+
+		if ldapCreated {
+			if delErr := a.ldap.DeleteUser(req.Username); delErr != nil {
+				log.Printf("WARNING: LDAP cleanup failed for user %s: %v", req.Username, delErr)
+			}
+		}
+
+		if delErr := portaldb.DeleteUserByID(compensateCtx, a.portalDB, userID); delErr != nil {
+			log.Printf("WARNING: DB cleanup failed for user %s (id=%d): %v — manual cleanup required", req.Username, userID, delErr)
 		}
 		return fmt.Errorf("%s: %w", step, cause)
 	}
@@ -314,6 +341,7 @@ func (a *API) createPortalUser(w http.ResponseWriter, r *http.Request) error {
 	if err := a.ldap.CreateUserWithGroups(ldapUser, a.cfg.LDAP.EveryoneGroup, a.cfg.LDAP.CommunityGroup); err != nil {
 		return compensate(err, "creating LDAP user")
 	}
+	ldapCreated = true
 
 	// 3. Create user in DataStore.
 	log.Printf("Creating DataStore user: %s", req.Username)

--- a/api/portalmgmt.go
+++ b/api/portalmgmt.go
@@ -192,6 +192,12 @@ func (a *API) createPortalUser(w http.ResponseWriter, r *http.Request) error {
 	if err := a.ensurePortalDB(); err != nil {
 		return err
 	}
+	if a.ldap == nil {
+		return httpErrorf(http.StatusServiceUnavailable, "LDAP integration not configured")
+	}
+	if a.ds == nil {
+		return httpErrorf(http.StatusServiceUnavailable, "DataStore integration not configured")
+	}
 
 	// Start with defaults, then overlay the request body on top.
 	req := kinds.PortalCreateUserDefaults()

--- a/api/portalmgmt.go
+++ b/api/portalmgmt.go
@@ -1,0 +1,327 @@
+package api
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"log"
+	"net/http"
+	"regexp"
+	"strconv"
+
+	"github.com/cyverse-de/portal-conductor/kinds"
+	"github.com/cyverse-de/portal-conductor/portaldb"
+)
+
+// usernamePattern matches valid usernames: lowercase alphanumeric only.
+var usernamePattern = regexp.MustCompile(`^[0-9a-z]+$`)
+
+// usernameValid checks whether a username matches the required format.
+func usernameValid(username string) bool {
+	return usernamePattern.MatchString(username)
+}
+
+// generatePassword creates a cryptographically random password string.
+func generatePassword() (string, error) {
+	b := make([]byte, 36)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("generating random password: %w", err)
+	}
+	return base64.URLEncoding.EncodeToString(b), nil
+}
+
+// ensurePortalDB returns an httpError if the portal database is not configured.
+func (a *API) ensurePortalDB() error {
+	if a.portalDB == nil {
+		return httpErrorf(http.StatusServiceUnavailable, "Portal database not configured")
+	}
+	return nil
+}
+
+// checkPortalUserExists reports whether a username exists or is restricted in
+// the portal database.
+//
+//	@Summary      Check if username exists in portal DB
+//	@Description  Checks both account_user and account_restrictedusername tables.
+//	@Produce      json
+//	@Param        username path string true "Username to check"
+//	@Success      200 {object} kinds.PortalUserExistsResponse
+//	@Failure      503 {object} map[string]string "Portal database not configured"
+//	@Security     BasicAuth
+//	@Router       /portal/users/{username}/exists [get]
+func (a *API) checkPortalUserExists(w http.ResponseWriter, r *http.Request) error {
+	if err := a.ensurePortalDB(); err != nil {
+		return err
+	}
+
+	username := r.PathValue("username")
+	ctx := r.Context()
+
+	valid := usernameValid(username)
+
+	userExists, err := portaldb.UserExistsByUsername(ctx, a.portalDB, username)
+	if err != nil {
+		return fmt.Errorf("checking user existence: %w", err)
+	}
+
+	isRestricted, err := portaldb.IsRestrictedUsername(ctx, a.portalDB, username)
+	if err != nil {
+		return fmt.Errorf("checking restricted username: %w", err)
+	}
+
+	writeJSON(w, http.StatusOK, kinds.PortalUserExistsResponse{
+		Username:     username,
+		Valid:        valid,
+		Exists:       userExists || isRestricted,
+		IsRestricted: isRestricted,
+	})
+	return nil
+}
+
+// checkPortalEmailExists reports whether an email address is already in use
+// in the portal database.
+//
+//	@Summary      Check if email exists in portal DB
+//	@Description  Case-insensitive check against account_emailaddress table.
+//	@Produce      json
+//	@Param        email path string true "Email address to check"
+//	@Success      200 {object} kinds.PortalEmailExistsResponse
+//	@Failure      503 {object} map[string]string "Portal database not configured"
+//	@Security     BasicAuth
+//	@Router       /portal/emails/{email}/exists [get]
+func (a *API) checkPortalEmailExists(w http.ResponseWriter, r *http.Request) error {
+	if err := a.ensurePortalDB(); err != nil {
+		return err
+	}
+
+	email := r.PathValue("email")
+	ctx := r.Context()
+
+	exists, err := portaldb.EmailExists(ctx, a.portalDB, email)
+	if err != nil {
+		return fmt.Errorf("checking email existence: %w", err)
+	}
+
+	writeJSON(w, http.StatusOK, kinds.PortalEmailExistsResponse{
+		Email:  email,
+		Exists: exists,
+	})
+	return nil
+}
+
+// validatePortalUsername validates a username's format, restriction status,
+// and availability.
+//
+//	@Summary      Validate username
+//	@Description  Checks format (lowercase alphanumeric), restricted list, and availability.
+//	@Produce      json
+//	@Param        username path string true "Username to validate"
+//	@Success      200 {object} kinds.UsernameValidationResponse
+//	@Failure      503 {object} map[string]string "Portal database not configured"
+//	@Security     BasicAuth
+//	@Router       /portal/users/{username}/validate [post]
+func (a *API) validatePortalUsername(w http.ResponseWriter, r *http.Request) error {
+	if err := a.ensurePortalDB(); err != nil {
+		return err
+	}
+
+	username := r.PathValue("username")
+	ctx := r.Context()
+
+	if !usernameValid(username) {
+		reason := "Username format is invalid."
+		writeJSON(w, http.StatusOK, kinds.UsernameValidationResponse{
+			Username: username,
+			Valid:    false,
+			Reason:   &reason,
+		})
+		return nil
+	}
+
+	isRestricted, err := portaldb.IsRestrictedUsername(ctx, a.portalDB, username)
+	if err != nil {
+		return fmt.Errorf("checking restricted username: %w", err)
+	}
+	if isRestricted {
+		reason := "Username is restricted."
+		writeJSON(w, http.StatusOK, kinds.UsernameValidationResponse{
+			Username: username,
+			Valid:    false,
+			Reason:   &reason,
+		})
+		return nil
+	}
+
+	exists, err := portaldb.UserExistsByUsername(ctx, a.portalDB, username)
+	if err != nil {
+		return fmt.Errorf("checking user existence: %w", err)
+	}
+	if exists {
+		reason := "Username already taken."
+		writeJSON(w, http.StatusOK, kinds.UsernameValidationResponse{
+			Username: username,
+			Valid:    false,
+			Reason:   &reason,
+		})
+		return nil
+	}
+
+	writeJSON(w, http.StatusOK, kinds.UsernameValidationResponse{
+		Username: username,
+		Valid:    true,
+		Reason:   nil,
+	})
+	return nil
+}
+
+// createPortalUser creates a user across all systems: Portal DB, LDAP,
+// DataStore, and optionally Terrain (job limits).
+//
+//	@Summary      Create user in all systems
+//	@Description  Full user registration: portal DB, LDAP, iRODS datastore, and Terrain job limits.
+//	@Accept       json
+//	@Produce      json
+//	@Param        request body kinds.PortalCreateUserRequest true "User creation request"
+//	@Success      201 {object} kinds.PortalCreateUserResponse
+//	@Failure      400 {object} map[string]string "Username/email conflict"
+//	@Failure      422 {object} kinds.ValidationErrorResponse "Validation error"
+//	@Failure      503 {object} map[string]string "Portal database not configured"
+//	@Security     BasicAuth
+//	@Router       /portal/users [post]
+func (a *API) createPortalUser(w http.ResponseWriter, r *http.Request) error {
+	if err := a.ensurePortalDB(); err != nil {
+		return err
+	}
+
+	// Start with defaults, then overlay the request body on top.
+	req := kinds.PortalCreateUserDefaults()
+	if err := decodeBody(r, &req, "username", "email", "first_name", "last_name"); err != nil {
+		return err
+	}
+
+	ctx := r.Context()
+
+	// Validate username format.
+	if !usernameValid(req.Username) {
+		return httpErrorf(http.StatusBadRequest, "Username format is invalid.")
+	}
+
+	// Check restricted.
+	isRestricted, err := portaldb.IsRestrictedUsername(ctx, a.portalDB, req.Username)
+	if err != nil {
+		return fmt.Errorf("checking restricted username: %w", err)
+	}
+	if isRestricted {
+		return httpErrorf(http.StatusBadRequest, "Username is restricted.")
+	}
+
+	// Check username taken.
+	userExists, err := portaldb.UserExistsByUsername(ctx, a.portalDB, req.Username)
+	if err != nil {
+		return fmt.Errorf("checking user existence: %w", err)
+	}
+	if userExists {
+		return httpErrorf(http.StatusBadRequest, "Username already taken.")
+	}
+
+	// Check email taken.
+	emailExists, err := portaldb.EmailExists(ctx, a.portalDB, req.Email)
+	if err != nil {
+		return fmt.Errorf("checking email existence: %w", err)
+	}
+	if emailExists {
+		return httpErrorf(http.StatusBadRequest, "Email already in use.")
+	}
+
+	// Generate a random password if none was provided. SSO users don't need
+	// one, but LDAP and iRODS require a password to be set.
+	password := req.Password
+	if password == "" {
+		password, err = generatePassword()
+		if err != nil {
+			return err
+		}
+	}
+
+	// Look up occupation name for the LDAP title field.
+	occupationName, err := portaldb.GetOccupationName(ctx, a.portalDB, req.OccupationID)
+	if err != nil {
+		return fmt.Errorf("looking up occupation: %w", err)
+	}
+	if occupationName == "" {
+		occupationName = "Unknown"
+	}
+
+	// 1. Create user in portal database.
+	log.Printf("Creating user in portal database: %s", req.Username)
+	userData := portaldb.CreateUserData{
+		Username:          req.Username,
+		Email:             req.Email,
+		Password:          "", // Portal DB password is empty; auth goes through Keycloak/LDAP.
+		FirstName:         req.FirstName,
+		LastName:          req.LastName,
+		Institution:       req.Institution,
+		Department:        req.Department,
+		OccupationID:      req.OccupationID,
+		FundingAgencyID:   req.FundingAgencyID,
+		GenderID:          req.GenderID,
+		EthnicityID:       req.EthnicityID,
+		RegionID:          req.RegionID,
+		ResearchAreaID:    req.ResearchAreaID,
+		AwareChannelID:    req.AwareChannelID,
+		GridInstitutionID: req.GridInstitutionID,
+		HasVerifiedEmail:  true, // SSO users arrive from a trusted IdP.
+	}
+	userID, err := portaldb.CreateUser(ctx, a.portalDB, userData)
+	if err != nil {
+		return fmt.Errorf("creating portal user: %w", err)
+	}
+
+	// 2. Create email address record. Marked as verified because SSO users
+	// arrive from a trusted IdP that has already validated their email.
+	log.Printf("Creating email address record for user %d", userID)
+	if err := portaldb.CreateEmailAddress(ctx, a.portalDB, userID, req.Email, true, true); err != nil {
+		return fmt.Errorf("creating email address: %w", err)
+	}
+
+	// 3. Create user in LDAP with default groups.
+	uidNumber := int(userID) + a.cfg.Security.UIDNumberOffset
+	log.Printf("Creating LDAP user: %s (uid: %d)", req.Username, uidNumber)
+
+	ldapUser := kinds.CreateUserRequest{
+		FirstName:    req.FirstName,
+		LastName:     req.LastName,
+		Email:        req.Email,
+		Username:     req.Username,
+		UserUID:      strconv.Itoa(uidNumber),
+		Password:     password,
+		Department:   req.Department,
+		Organization: req.Institution,
+		Title:        occupationName,
+	}
+	if err := a.ldap.CreateUserWithGroups(ldapUser, a.cfg.LDAP.EveryoneGroup, a.cfg.LDAP.CommunityGroup); err != nil {
+		return fmt.Errorf("creating LDAP user: %w", err)
+	}
+
+	// 4. Create user in DataStore.
+	log.Printf("Creating DataStore user: %s", req.Username)
+	if err := a.ds.CreateUserWithPermissions(req.Username, password, a.cfg.IRODS.IPCServicesUser, a.cfg.IRODS.AdminUser); err != nil {
+		return fmt.Errorf("creating DataStore user: %w", err)
+	}
+
+	// 5. Set job limits via Terrain (optional).
+	if a.terrain != nil && req.JobLimit != nil {
+		log.Printf("Setting job limits for user: %s", req.Username)
+		if limitErr := a.terrain.SetConcurrentJobLimits(req.Username, *req.JobLimit); limitErr != nil {
+			log.Printf("WARNING: Failed to set job limits for %s: %v", req.Username, limitErr)
+			// Continue — job limits are not critical.
+		}
+	}
+
+	log.Printf("User creation completed: %s (id=%d)", req.Username, userID)
+	writeJSON(w, http.StatusCreated, kinds.PortalCreateUserResponse{
+		User:   req.Username,
+		UserID: userID,
+	})
+	return nil
+}

--- a/api/portalmgmt.go
+++ b/api/portalmgmt.go
@@ -285,7 +285,7 @@ func (a *API) createPortalUser(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	// 3. Create user in LDAP with default groups.
-	uidNumber := int(userID) + a.cfg.Security.UIDNumberOffset
+	uidNumber := userID + int64(a.cfg.Security.UIDNumberOffset)
 	log.Printf("Creating LDAP user: %s (uid: %d)", req.Username, uidNumber)
 
 	ldapUser := kinds.CreateUserRequest{
@@ -293,7 +293,7 @@ func (a *API) createPortalUser(w http.ResponseWriter, r *http.Request) error {
 		LastName:     req.LastName,
 		Email:        req.Email,
 		Username:     req.Username,
-		UserUID:      strconv.Itoa(uidNumber),
+		UserUID:      strconv.FormatInt(uidNumber, 10),
 		Password:     password,
 		Department:   req.Department,
 		Organization: req.Institution,

--- a/api/portalmgmt_test.go
+++ b/api/portalmgmt_test.go
@@ -1,0 +1,158 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/cyverse-de/portal-conductor/kinds"
+)
+
+func TestUsernameValid(t *testing.T) {
+	tests := []struct {
+		username string
+		valid    bool
+	}{
+		{"johndoe", true},
+		{"abc123", true},
+		{"a", true},
+		{"0", true},
+		{"", false},
+		{"John", false},       // uppercase
+		{"john_doe", false},   // underscore
+		{"john-doe", false},   // hyphen
+		{"john.doe", false},   // dot
+		{"john doe", false},   // space
+		{"john@doe", false},   // special char
+		{"john123!", false},   // exclamation
+	}
+	for _, tt := range tests {
+		t.Run(tt.username, func(t *testing.T) {
+			got := usernameValid(tt.username)
+			if got != tt.valid {
+				t.Errorf("usernameValid(%q) = %v, want %v", tt.username, got, tt.valid)
+			}
+		})
+	}
+}
+
+func TestGeneratePassword(t *testing.T) {
+	pw, err := generatePassword()
+	if err != nil {
+		t.Fatalf("generatePassword() error: %v", err)
+	}
+	if len(pw) == 0 {
+		t.Fatal("generatePassword() returned empty string")
+	}
+	// base64 of 36 bytes = 48 characters
+	if len(pw) != 48 {
+		t.Errorf("generatePassword() length = %d, want 48", len(pw))
+	}
+
+	// Two calls should produce different results.
+	pw2, _ := generatePassword()
+	if pw == pw2 {
+		t.Error("generatePassword() produced duplicate passwords")
+	}
+}
+
+func TestPortalEndpointsReturn503WhenDBNil(t *testing.T) {
+	handler := New(testConfig(), nil, nil, nil, nil, nil, "", nil).Handler()
+
+	endpoints := []struct {
+		method string
+		path   string
+	}{
+		{http.MethodGet, "/portal/users/testuser/exists"},
+		{http.MethodGet, "/portal/emails/test@example.com/exists"},
+		{http.MethodPost, "/portal/users/testuser/validate"},
+		{http.MethodPost, "/portal/users"},
+	}
+
+	for _, ep := range endpoints {
+		t.Run(ep.method+" "+ep.path, func(t *testing.T) {
+			body := ""
+			if ep.method == http.MethodPost && ep.path == "/portal/users" {
+				body = `{"username":"foo","email":"foo@bar.com","first_name":"Foo","last_name":"Bar"}`
+			}
+			rec := doRequest(t, handler, ep.method, ep.path, "admin", "secret", body)
+			if rec.Code != http.StatusServiceUnavailable {
+				t.Errorf("got status %d, want %d", rec.Code, http.StatusServiceUnavailable)
+			}
+		})
+	}
+}
+
+func TestCreatePortalUserDefaultsApplied(t *testing.T) {
+	// Verify that PortalCreateUserDefaults produces expected values.
+	defaults := kinds.PortalCreateUserDefaults()
+
+	if defaults.Department != "Not Provided" {
+		t.Errorf("Department = %q, want %q", defaults.Department, "Not Provided")
+	}
+	if defaults.Institution != "Not Provided" {
+		t.Errorf("Institution = %q, want %q", defaults.Institution, "Not Provided")
+	}
+	if defaults.OccupationID != 13 {
+		t.Errorf("OccupationID = %d, want 13", defaults.OccupationID)
+	}
+	if defaults.FundingAgencyID != 21 {
+		t.Errorf("FundingAgencyID = %d, want 21", defaults.FundingAgencyID)
+	}
+	if defaults.GenderID != 11 {
+		t.Errorf("GenderID = %d, want 11", defaults.GenderID)
+	}
+	if defaults.EthnicityID != 8 {
+		t.Errorf("EthnicityID = %d, want 8", defaults.EthnicityID)
+	}
+	if defaults.RegionID != 4394 {
+		t.Errorf("RegionID = %d, want 4394", defaults.RegionID)
+	}
+	if defaults.ResearchAreaID != 155 {
+		t.Errorf("ResearchAreaID = %d, want 155", defaults.ResearchAreaID)
+	}
+	if defaults.AwareChannelID != 11 {
+		t.Errorf("AwareChannelID = %d, want 11", defaults.AwareChannelID)
+	}
+}
+
+func TestCreatePortalUserDefaultsOverlaidByJSON(t *testing.T) {
+	// Verify that JSON unmarshaling onto defaults correctly overlays
+	// provided values while keeping defaults for omitted ones.
+	defaults := kinds.PortalCreateUserDefaults()
+	body := `{"username":"jdoe","email":"j@example.com","first_name":"Jane","last_name":"Doe","department":"Biology"}`
+
+	if err := json.Unmarshal([]byte(body), &defaults); err != nil {
+		t.Fatalf("Unmarshal error: %v", err)
+	}
+
+	if defaults.Username != "jdoe" {
+		t.Errorf("Username = %q, want %q", defaults.Username, "jdoe")
+	}
+	if defaults.Department != "Biology" {
+		t.Errorf("Department = %q, want %q (should be overridden)", defaults.Department, "Biology")
+	}
+	// These should still be defaults since they weren't in the JSON.
+	if defaults.OccupationID != 13 {
+		t.Errorf("OccupationID = %d, want 13 (should remain default)", defaults.OccupationID)
+	}
+	if defaults.RegionID != 4394 {
+		t.Errorf("RegionID = %d, want 4394 (should remain default)", defaults.RegionID)
+	}
+}
+
+func TestCreatePortalUserValidationNoAuth(t *testing.T) {
+	handler := New(testConfig(), nil, nil, nil, nil, nil, "", nil).Handler()
+
+	// No auth should return 401.
+	req := httptest.NewRequest(http.MethodPost, "/portal/users", strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("got status %d, want %d", rec.Code, http.StatusUnauthorized)
+	}
+}

--- a/api/portalmgmt_test.go
+++ b/api/portalmgmt_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"database/sql"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -8,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/cyverse-de/portal-conductor/kinds"
+	"github.com/cyverse-de/portal-conductor/ldapclient"
 )
 
 func TestUsernameValid(t *testing.T) {
@@ -80,6 +82,41 @@ func TestPortalEndpointsReturn503WhenDBNil(t *testing.T) {
 			rec := doRequest(t, handler, ep.method, ep.path, "admin", "secret", body)
 			if rec.Code != http.StatusServiceUnavailable {
 				t.Errorf("got status %d, want %d", rec.Code, http.StatusServiceUnavailable)
+			}
+		})
+	}
+}
+
+func TestCreatePortalUserReturns503WhenRequiredDependenciesMissing(t *testing.T) {
+	portalDB := &sql.DB{}
+
+	tests := []struct {
+		name       string
+		ldap       *ldapclient.Client
+		wantDetail string
+	}{
+		{
+			name:       "ldap missing",
+			ldap:       nil,
+			wantDetail: "LDAP integration not configured",
+		},
+		{
+			name:       "datastore missing",
+			ldap:       &ldapclient.Client{},
+			wantDetail: "DataStore integration not configured",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := New(testConfig(), tt.ldap, nil, nil, nil, nil, "", portalDB).Handler()
+			rec := doRequest(t, handler, http.MethodPost, "/portal/users", "admin", "secret", "")
+
+			if rec.Code != http.StatusServiceUnavailable {
+				t.Fatalf("got status %d, want %d", rec.Code, http.StatusServiceUnavailable)
+			}
+			if d := detailOf(t, rec); d != tt.wantDetail {
+				t.Errorf("got detail %v, want %s", d, tt.wantDetail)
 			}
 		})
 	}

--- a/api/portalmgmt_test.go
+++ b/api/portalmgmt_test.go
@@ -22,13 +22,13 @@ func TestUsernameValid(t *testing.T) {
 		{"a", true},
 		{"0", true},
 		{"", false},
-		{"John", false},       // uppercase
-		{"john_doe", false},   // underscore
-		{"john-doe", false},   // hyphen
-		{"john.doe", false},   // dot
-		{"john doe", false},   // space
-		{"john@doe", false},   // special char
-		{"john123!", false},   // exclamation
+		{"John", false},     // uppercase
+		{"john_doe", false}, // underscore
+		{"john-doe", false}, // hyphen
+		{"john.doe", false}, // dot
+		{"john doe", false}, // space
+		{"john@doe", false}, // special char
+		{"john123!", false}, // exclamation
 	}
 	for _, tt := range tests {
 		t.Run(tt.username, func(t *testing.T) {

--- a/api/server.go
+++ b/api/server.go
@@ -6,6 +6,7 @@ package api
 import (
 	"bytes"
 	"crypto/subtle"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -36,6 +37,11 @@ type API struct {
 	mailman *mailman.Client
 	email   *emailsvc.Service
 
+	// portalDB is the connection to the portal PostgreSQL database. It may
+	// be nil if the portal database is not configured (endpoints will
+	// return 503).
+	portalDB *sql.DB
+
 	// deletionAppID caches the user-deletion app ID; it may be resolved
 	// lazily when the startup lookup failed.
 	appIDMu       sync.Mutex
@@ -43,7 +49,7 @@ type API struct {
 }
 
 // New assembles the API from its dependencies. deletionAppID may be empty
-// when unresolved at startup.
+// when unresolved at startup. portalDB may be nil if not configured.
 func New(
 	cfg *config.Config,
 	ldapClient *ldapclient.Client,
@@ -52,6 +58,7 @@ func New(
 	mailmanClient *mailman.Client,
 	emailService *emailsvc.Service,
 	deletionAppID string,
+	portalDB *sql.DB,
 ) *API {
 	return &API{
 		cfg:           cfg,
@@ -61,6 +68,7 @@ func New(
 		mailman:       mailmanClient,
 		email:         emailService,
 		deletionAppID: deletionAppID,
+		portalDB:      portalDB,
 	}
 }
 
@@ -274,6 +282,12 @@ func (a *API) Handler() http.Handler {
 	// Terrain
 	mux.Handle("GET /terrain/users/{username}/job-limits", a.protected(a.getJobLimits))
 	mux.Handle("POST /terrain/users/{username}/job-limits", a.protected(a.setJobLimits))
+
+	// Portal database management
+	mux.Handle("GET /portal/users/{username}/exists", a.protected(a.checkPortalUserExists))
+	mux.Handle("GET /portal/emails/{email}/exists", a.protected(a.checkPortalEmailExists))
+	mux.Handle("POST /portal/users/{username}/validate", a.protected(a.validatePortalUsername))
+	mux.Handle("POST /portal/users", a.protected(a.createPortalUser))
 
 	mux.HandleFunc("/", notFound)
 

--- a/api/server_test.go
+++ b/api/server_test.go
@@ -62,7 +62,7 @@ func detailOf(t *testing.T, rec *httptest.ResponseRecorder) any {
 }
 
 func TestGreetingAndNotFound(t *testing.T) {
-	handler := New(testConfig(), nil, nil, nil, nil, nil, "").Handler()
+	handler := New(testConfig(), nil, nil, nil, nil, nil, "", nil).Handler()
 
 	t.Run("greeting is unauthenticated", func(t *testing.T) {
 		rec := doRequest(t, handler, http.MethodGet, "/", "", "", "")
@@ -110,7 +110,7 @@ func TestAuthentication(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := testConfig()
 			cfg.Auth.Enabled = tt.authEnabled
-			handler := New(cfg, nil, nil, nil, nil, nil, "").Handler()
+			handler := New(cfg, nil, nil, nil, nil, nil, "", nil).Handler()
 
 			rec := doRequest(t, handler, http.MethodGet, path, tt.user, tt.pass, "")
 			if rec.Code != tt.wantStatus {
@@ -132,7 +132,7 @@ func TestAuthEnabledWithoutConfiguredCredentials(t *testing.T) {
 	cfg := testConfig()
 	cfg.Auth.Username = ""
 	cfg.Auth.Password = ""
-	handler := New(cfg, nil, nil, nil, nil, nil, "").Handler()
+	handler := New(cfg, nil, nil, nil, nil, nil, "", nil).Handler()
 
 	rec := doRequest(t, handler, http.MethodGet, "/mailinglists/x/members", "any", "thing", "")
 	if rec.Code != http.StatusUnauthorized {
@@ -141,7 +141,7 @@ func TestAuthEnabledWithoutConfiguredCredentials(t *testing.T) {
 }
 
 func TestAsyncNotConfigured(t *testing.T) {
-	handler := New(testConfig(), nil, nil, nil, nil, nil, "").Handler()
+	handler := New(testConfig(), nil, nil, nil, nil, nil, "", nil).Handler()
 
 	const analysisID = "6ded3c88-65d7-11f1-b562-32f7aa1defe5"
 	paths := []struct {
@@ -166,7 +166,7 @@ func TestAsyncNotConfigured(t *testing.T) {
 }
 
 func TestAsyncRejectsInvalidAnalysisID(t *testing.T) {
-	handler := New(testConfig(), nil, nil, nil, nil, nil, "").Handler()
+	handler := New(testConfig(), nil, nil, nil, nil, nil, "", nil).Handler()
 
 	for _, p := range []string{"/async/status/not-a-uuid", "/async/analyses/not-a-uuid/details"} {
 		t.Run(p, func(t *testing.T) {
@@ -182,7 +182,7 @@ func TestAsyncRejectsInvalidAnalysisID(t *testing.T) {
 }
 
 func TestRequestValidation(t *testing.T) {
-	handler := New(testConfig(), nil, nil, nil, nil, nil, "").Handler()
+	handler := New(testConfig(), nil, nil, nil, nil, nil, "", nil).Handler()
 
 	tests := []struct {
 		name         string
@@ -243,7 +243,7 @@ func TestRequestValidation(t *testing.T) {
 }
 
 func TestTrailingSlashUserRoute(t *testing.T) {
-	handler := New(testConfig(), nil, nil, nil, nil, nil, "").Handler()
+	handler := New(testConfig(), nil, nil, nil, nil, nil, "", nil).Handler()
 
 	// Both /users and /users/ must hit the create-user route; an incomplete
 	// body proves it reached validation (422) rather than the 404 catch-all.

--- a/api/terrainmgmt_test.go
+++ b/api/terrainmgmt_test.go
@@ -49,7 +49,7 @@ func TestGetJobLimits(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			handler := New(testConfig(), nil, nil, terrainClient, nil, nil, "").Handler()
+			handler := New(testConfig(), nil, nil, terrainClient, nil, nil, "", nil).Handler()
 
 			rec := doRequest(t, handler, http.MethodGet, "/terrain/users/john/job-limits", "admin", "secret", "")
 			if rec.Code != tt.wantStatus {

--- a/config/config.go
+++ b/config/config.go
@@ -128,6 +128,11 @@ type PortalDB struct {
 	SSLMode  string     `json:"sslmode"`
 }
 
+// Security holds security-related settings for user provisioning.
+type Security struct {
+	UIDNumberOffset int `json:"uid_number_offset"`
+}
+
 // Config is the top-level configuration for portal-conductor.
 type Config struct {
 	SSL      SSL      `json:"ssl"`
@@ -139,6 +144,7 @@ type Config struct {
 	Mailman  Mailman  `json:"mailman"`
 	SMTP     SMTP     `json:"smtp"`
 	PortalDB PortalDB `json:"portal_db"`
+	Security Security `json:"security"`
 }
 
 // defaults returns a Config pre-populated with the same defaults the Python
@@ -157,6 +163,7 @@ func defaults() *Config {
 			SystemID:            "de",
 		},
 		PortalDB: PortalDB{Port: "5432", SSLMode: "disable"},
+		Security: Security{UIDNumberOffset: 2831},
 	}
 }
 
@@ -260,6 +267,9 @@ func fromEnv() *Config {
 		User:     os.Getenv("PORTAL_DB_USER"),
 		Password: os.Getenv("PORTAL_DB_PASSWORD"),
 		SSLMode:  envOr("PORTAL_DB_SSLMODE", "disable"),
+	}
+	c.Security = Security{
+		UIDNumberOffset: envInt("UID_NUMBER_OFFSET", 2831),
 	}
 	return c
 }

--- a/kinds/kinds.go
+++ b/kinds/kinds.go
@@ -202,22 +202,22 @@ type ValidationErrorResponse struct {
 // FirstName, and LastName are required; all other fields have sensible
 // defaults for SSO-provisioned users.
 type PortalCreateUserRequest struct {
-	Username        string `json:"username"`
-	Email           string `json:"email"`
-	FirstName       string `json:"first_name"`
-	LastName        string `json:"last_name"`
-	Password        string `json:"password"`
-	Department      string `json:"department"`
-	Institution     string `json:"institution"`
-	OccupationID    int    `json:"occupation_id"`
-	FundingAgencyID int    `json:"funding_agency_id"`
-	GenderID        int    `json:"gender_id"`
-	EthnicityID     int    `json:"ethnicity_id"`
-	RegionID        int    `json:"region_id"`
-	ResearchAreaID  int    `json:"research_area_id"`
-	AwareChannelID  int    `json:"aware_channel_id"`
-	GridInstitutionID *int `json:"grid_institution_id"`
-	JobLimit        *int   `json:"job_limit"`
+	Username          string `json:"username"`
+	Email             string `json:"email"`
+	FirstName         string `json:"first_name"`
+	LastName          string `json:"last_name"`
+	Password          string `json:"password"`
+	Department        string `json:"department"`
+	Institution       string `json:"institution"`
+	OccupationID      int    `json:"occupation_id"`
+	FundingAgencyID   int    `json:"funding_agency_id"`
+	GenderID          int    `json:"gender_id"`
+	EthnicityID       int    `json:"ethnicity_id"`
+	RegionID          int    `json:"region_id"`
+	ResearchAreaID    int    `json:"research_area_id"`
+	AwareChannelID    int    `json:"aware_channel_id"`
+	GridInstitutionID *int   `json:"grid_institution_id"`
+	JobLimit          *int   `json:"job_limit"`
 }
 
 // PortalCreateUserDefaults returns a PortalCreateUserRequest pre-populated

--- a/kinds/kinds.go
+++ b/kinds/kinds.go
@@ -196,3 +196,73 @@ type ValidationError struct {
 type ValidationErrorResponse struct {
 	Detail []ValidationError `json:"detail"`
 }
+
+// PortalCreateUserRequest holds the fields for creating a user across all
+// systems (Portal DB, LDAP, DataStore, Terrain). Only Username, Email,
+// FirstName, and LastName are required; all other fields have sensible
+// defaults for SSO-provisioned users.
+type PortalCreateUserRequest struct {
+	Username        string `json:"username"`
+	Email           string `json:"email"`
+	FirstName       string `json:"first_name"`
+	LastName        string `json:"last_name"`
+	Password        string `json:"password"`
+	Department      string `json:"department"`
+	Institution     string `json:"institution"`
+	OccupationID    int    `json:"occupation_id"`
+	FundingAgencyID int    `json:"funding_agency_id"`
+	GenderID        int    `json:"gender_id"`
+	EthnicityID     int    `json:"ethnicity_id"`
+	RegionID        int    `json:"region_id"`
+	ResearchAreaID  int    `json:"research_area_id"`
+	AwareChannelID  int    `json:"aware_channel_id"`
+	GridInstitutionID *int `json:"grid_institution_id"`
+	JobLimit        *int   `json:"job_limit"`
+}
+
+// PortalCreateUserDefaults returns a PortalCreateUserRequest pre-populated
+// with "Not Provided" defaults for all optional fields.
+func PortalCreateUserDefaults() PortalCreateUserRequest {
+	return PortalCreateUserRequest{
+		Department:      "Not Provided",
+		Institution:     "Not Provided",
+		OccupationID:    13,   // "Not Provided"
+		FundingAgencyID: 21,   // "Not Provided"
+		GenderID:        11,   // "Not Provided"
+		EthnicityID:     8,    // "Not Provided"
+		RegionID:        4394, // "Not Provided" (US)
+		ResearchAreaID:  155,  // "Not Provided"
+		AwareChannelID:  11,   // "Not Provided"
+	}
+}
+
+// PortalCreateUserResponse is returned after successfully creating a user
+// across all systems.
+type PortalCreateUserResponse struct {
+	User   string `json:"user"`
+	UserID int64  `json:"user_id"`
+}
+
+// PortalUserExistsResponse reports whether a username exists or is restricted
+// in the portal database.
+type PortalUserExistsResponse struct {
+	Username     string `json:"username"`
+	Valid        bool   `json:"valid"`
+	Exists       bool   `json:"exists"`
+	IsRestricted bool   `json:"is_restricted"`
+}
+
+// PortalEmailExistsResponse reports whether an email address is already in
+// use in the portal database.
+type PortalEmailExistsResponse struct {
+	Email  string `json:"email"`
+	Exists bool   `json:"exists"`
+}
+
+// UsernameValidationResponse reports whether a username is valid and
+// available.
+type UsernameValidationResponse struct {
+	Username string  `json:"username"`
+	Valid    bool    `json:"valid"`
+	Reason   *string `json:"reason"`
+}

--- a/main.go
+++ b/main.go
@@ -4,6 +4,8 @@
 package main
 
 import (
+	"context"
+	"database/sql"
 	"flag"
 	"fmt"
 	"log"
@@ -20,6 +22,7 @@ import (
 	"github.com/cyverse-de/portal-conductor/emailsvc"
 	"github.com/cyverse-de/portal-conductor/ldapclient"
 	"github.com/cyverse-de/portal-conductor/mailman"
+	"github.com/cyverse-de/portal-conductor/portaldb"
 	"github.com/cyverse-de/portal-conductor/terrain"
 
 	_ "github.com/cyverse-de/portal-conductor/docs"
@@ -83,13 +86,31 @@ func buildAPI(cfg *config.Config) http.Handler {
 
 	emailService := emailsvc.New(cfg.SMTP)
 
+	// Connect to the portal database if configured. This is optional;
+	// the /portal/* endpoints will return 503 if not available.
+	var portalDBConn *sql.DB
+	if cfg.PortalDB.Host != "" && cfg.PortalDB.Name != "" {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		portalDBConn, err = portaldb.Connect(ctx, cfg.PortalDB)
+		if err != nil {
+			log.Printf("WARNING: Failed to connect to portal database: %v", err)
+			log.Printf("Portal database endpoints will return 503")
+		} else {
+			log.Printf("Connected to portal database at %s:%d/%s",
+				cfg.PortalDB.Host, cfg.PortalDB.Port.Int(5432), cfg.PortalDB.Name)
+		}
+	} else {
+		log.Printf("Portal database not configured; /portal/* endpoints disabled")
+	}
+
 	// The user-deletion app ID is resolved by name lazily on first async use,
 	// so an unreachable Terrain can't block startup and delay health checks.
 	if cfg.TerrainAsyncConfigured() && cfg.Terrain.UserDeletionAppID == "" {
 		log.Printf("User-deletion app ID not set; it will be resolved from name '%s' on first async use", cfg.Terrain.UserDeletionAppName)
 	}
 
-	a := api.New(cfg, ldapClient, ds, terrainClient, mailmanClient, emailService, cfg.Terrain.UserDeletionAppID)
+	a := api.New(cfg, ldapClient, ds, terrainClient, mailmanClient, emailService, cfg.Terrain.UserDeletionAppID, portalDBConn)
 	return a.Handler()
 }
 

--- a/portaldb/usercreation.go
+++ b/portaldb/usercreation.go
@@ -33,8 +33,8 @@ type CreateUserData struct {
 func UserExistsByUsername(ctx context.Context, db *sql.DB, username string) (bool, error) {
 	var exists bool
 	err := db.QueryRowContext(ctx,
-		"SELECT EXISTS(SELECT 1 FROM account_user WHERE username = $1)",
-		username,
+		"SELECT EXISTS(SELECT 1 FROM account_user WHERE LOWER(username) = $1)",
+		strings.ToLower(username),
 	).Scan(&exists)
 	if err != nil {
 		return false, fmt.Errorf("checking username existence: %w", err)
@@ -46,8 +46,8 @@ func UserExistsByUsername(ctx context.Context, db *sql.DB, username string) (boo
 func IsRestrictedUsername(ctx context.Context, db *sql.DB, username string) (bool, error) {
 	var exists bool
 	err := db.QueryRowContext(ctx,
-		"SELECT EXISTS(SELECT 1 FROM account_restrictedusername WHERE username = $1)",
-		username,
+		"SELECT EXISTS(SELECT 1 FROM account_restrictedusername WHERE LOWER(username) = $1)",
+		strings.ToLower(username),
 	).Scan(&exists)
 	if err != nil {
 		return false, fmt.Errorf("checking restricted username: %w", err)

--- a/portaldb/usercreation.go
+++ b/portaldb/usercreation.go
@@ -12,22 +12,22 @@ import (
 // CreateUserData holds the fields required to insert a new user into the
 // portal database's account_user table.
 type CreateUserData struct {
-	Username        string
-	Email           string
-	Password        string
-	FirstName       string
-	LastName        string
-	Institution     string
-	Department      string
-	OccupationID    int
-	FundingAgencyID int
-	GenderID        int
-	EthnicityID     int
-	RegionID        int
-	ResearchAreaID  int
-	AwareChannelID  int
+	Username          string
+	Email             string
+	Password          string
+	FirstName         string
+	LastName          string
+	Institution       string
+	Department        string
+	OccupationID      int
+	FundingAgencyID   int
+	GenderID          int
+	EthnicityID       int
+	RegionID          int
+	ResearchAreaID    int
+	AwareChannelID    int
 	GridInstitutionID *int
-	HasVerifiedEmail bool
+	HasVerifiedEmail  bool
 }
 
 // UserExistsByUsername checks whether a username already exists in account_user.

--- a/portaldb/usercreation.go
+++ b/portaldb/usercreation.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"log"
 	"strings"
 	"time"
 )
@@ -86,12 +87,59 @@ func GetOccupationName(ctx context.Context, db *sql.DB, occupationID int) (strin
 	return name, nil
 }
 
-// CreateUser inserts a new user into account_user and returns the new user's
-// database ID.
-func CreateUser(ctx context.Context, db *sql.DB, data CreateUserData) (int64, error) {
+// CreateUserWithEmail creates a user record and its associated email address
+// in a single transaction. Returns the new user's database ID.
+func CreateUserWithEmail(ctx context.Context, db *sql.DB, data CreateUserData, emailVerified bool) (int64, error) {
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, fmt.Errorf("beginning transaction: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	userID, err := createUserTx(ctx, tx, data)
+	if err != nil {
+		return 0, err
+	}
+
+	if err := createEmailAddressTx(ctx, tx, userID, data.Email, true, emailVerified); err != nil {
+		return 0, err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return 0, fmt.Errorf("committing user creation transaction: %w", err)
+	}
+	return userID, nil
+}
+
+// DeleteUserByID removes a user and their email addresses from the portal
+// database. This is used as a best-effort compensation when downstream
+// provisioning (LDAP, DataStore) fails after the portal DB insert succeeded.
+func DeleteUserByID(ctx context.Context, db *sql.DB, userID int64) error {
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("beginning compensation transaction: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	if _, err := tx.ExecContext(ctx, "DELETE FROM account_emailaddress WHERE user_id = $1", userID); err != nil {
+		return fmt.Errorf("deleting email addresses for user %d: %w", userID, err)
+	}
+	if _, err := tx.ExecContext(ctx, "DELETE FROM account_user WHERE id = $1", userID); err != nil {
+		return fmt.Errorf("deleting user %d: %w", userID, err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("committing compensation transaction: %w", err)
+	}
+	log.Printf("Compensation: removed portal DB records for user ID %d", userID)
+	return nil
+}
+
+// createUserTx inserts a new user within an existing transaction.
+func createUserTx(ctx context.Context, tx *sql.Tx, data CreateUserData) (int64, error) {
 	now := time.Now().UTC()
 	var userID int64
-	err := db.QueryRowContext(ctx, `
+	err := tx.QueryRowContext(ctx, `
 		INSERT INTO account_user (
 			username, email, password, first_name, last_name,
 			institution, department, occupation_id, funding_agency_id,
@@ -121,15 +169,15 @@ func CreateUser(ctx context.Context, db *sql.DB, data CreateUserData) (int64, er
 		data.RegionID,
 		data.ResearchAreaID,
 		data.AwareChannelID,
-		false,                // is_superuser
-		false,                // is_staff
-		true,                 // is_active
+		false,                 // is_superuser
+		false,                 // is_staff
+		true,                  // is_active
 		data.HasVerifiedEmail, // has_verified_email
-		true,                 // participate_in_study
-		true,                 // subscribe_to_newsletter
-		"",                   // orcid_id
-		now,                  // date_joined
-		now,                  // updated_at
+		true,                  // participate_in_study
+		true,                  // subscribe_to_newsletter
+		"",                    // orcid_id
+		now,                   // date_joined
+		now,                   // updated_at
 		data.GridInstitutionID,
 	).Scan(&userID)
 	if err != nil {
@@ -138,10 +186,10 @@ func CreateUser(ctx context.Context, db *sql.DB, data CreateUserData) (int64, er
 	return userID, nil
 }
 
-// CreateEmailAddress inserts an email address record for a user.
-func CreateEmailAddress(ctx context.Context, db *sql.DB, userID int64, email string, primary bool, verified bool) error {
+// createEmailAddressTx inserts an email address record within an existing transaction.
+func createEmailAddressTx(ctx context.Context, tx *sql.Tx, userID int64, email string, primary bool, verified bool) error {
 	now := time.Now().UTC()
-	_, err := db.ExecContext(ctx, `
+	_, err := tx.ExecContext(ctx, `
 		INSERT INTO account_emailaddress (
 			user_id, email, "primary", verified, created_at, updated_at
 		) VALUES ($1, $2, $3, $4, $5, $6)`,

--- a/portaldb/usercreation.go
+++ b/portaldb/usercreation.go
@@ -1,0 +1,159 @@
+package portaldb
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// CreateUserData holds the fields required to insert a new user into the
+// portal database's account_user table.
+type CreateUserData struct {
+	Username        string
+	Email           string
+	Password        string
+	FirstName       string
+	LastName        string
+	Institution     string
+	Department      string
+	OccupationID    int
+	FundingAgencyID int
+	GenderID        int
+	EthnicityID     int
+	RegionID        int
+	ResearchAreaID  int
+	AwareChannelID  int
+	GridInstitutionID *int
+	HasVerifiedEmail bool
+}
+
+// UserExistsByUsername checks whether a username already exists in account_user.
+func UserExistsByUsername(ctx context.Context, db *sql.DB, username string) (bool, error) {
+	var exists bool
+	err := db.QueryRowContext(ctx,
+		"SELECT EXISTS(SELECT 1 FROM account_user WHERE username = $1)",
+		username,
+	).Scan(&exists)
+	if err != nil {
+		return false, fmt.Errorf("checking username existence: %w", err)
+	}
+	return exists, nil
+}
+
+// IsRestrictedUsername checks whether a username is in the restricted list.
+func IsRestrictedUsername(ctx context.Context, db *sql.DB, username string) (bool, error) {
+	var exists bool
+	err := db.QueryRowContext(ctx,
+		"SELECT EXISTS(SELECT 1 FROM account_restrictedusername WHERE username = $1)",
+		username,
+	).Scan(&exists)
+	if err != nil {
+		return false, fmt.Errorf("checking restricted username: %w", err)
+	}
+	return exists, nil
+}
+
+// EmailExists checks whether an email address exists in account_emailaddress
+// (case-insensitive).
+func EmailExists(ctx context.Context, db *sql.DB, email string) (bool, error) {
+	var exists bool
+	err := db.QueryRowContext(ctx,
+		"SELECT EXISTS(SELECT 1 FROM account_emailaddress WHERE LOWER(email) = LOWER($1))",
+		strings.ToLower(email),
+	).Scan(&exists)
+	if err != nil {
+		return false, fmt.Errorf("checking email existence: %w", err)
+	}
+	return exists, nil
+}
+
+// GetOccupationName returns the name for an occupation ID, or empty string if
+// not found.
+func GetOccupationName(ctx context.Context, db *sql.DB, occupationID int) (string, error) {
+	var name string
+	err := db.QueryRowContext(ctx,
+		"SELECT name FROM account_occupation WHERE id = $1",
+		occupationID,
+	).Scan(&name)
+	if err == sql.ErrNoRows {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("looking up occupation name: %w", err)
+	}
+	return name, nil
+}
+
+// CreateUser inserts a new user into account_user and returns the new user's
+// database ID.
+func CreateUser(ctx context.Context, db *sql.DB, data CreateUserData) (int64, error) {
+	now := time.Now().UTC()
+	var userID int64
+	err := db.QueryRowContext(ctx, `
+		INSERT INTO account_user (
+			username, email, password, first_name, last_name,
+			institution, department, occupation_id, funding_agency_id,
+			gender_id, ethnicity_id, region_id, research_area_id,
+			aware_channel_id, is_superuser, is_staff, is_active,
+			has_verified_email, participate_in_study, subscribe_to_newsletter,
+			orcid_id, date_joined, updated_at, grid_institution_id
+		) VALUES (
+			$1, $2, $3, $4, $5,
+			$6, $7, $8, $9,
+			$10, $11, $12, $13,
+			$14, $15, $16, $17,
+			$18, $19, $20,
+			$21, $22, $23, $24
+		) RETURNING id`,
+		data.Username,
+		strings.ToLower(data.Email),
+		data.Password,
+		data.FirstName,
+		data.LastName,
+		data.Institution,
+		data.Department,
+		data.OccupationID,
+		data.FundingAgencyID,
+		data.GenderID,
+		data.EthnicityID,
+		data.RegionID,
+		data.ResearchAreaID,
+		data.AwareChannelID,
+		false,                // is_superuser
+		false,                // is_staff
+		true,                 // is_active
+		data.HasVerifiedEmail, // has_verified_email
+		true,                 // participate_in_study
+		true,                 // subscribe_to_newsletter
+		"",                   // orcid_id
+		now,                  // date_joined
+		now,                  // updated_at
+		data.GridInstitutionID,
+	).Scan(&userID)
+	if err != nil {
+		return 0, fmt.Errorf("inserting user into portal database: %w", err)
+	}
+	return userID, nil
+}
+
+// CreateEmailAddress inserts an email address record for a user.
+func CreateEmailAddress(ctx context.Context, db *sql.DB, userID int64, email string, primary bool, verified bool) error {
+	now := time.Now().UTC()
+	_, err := db.ExecContext(ctx, `
+		INSERT INTO account_emailaddress (
+			user_id, email, "primary", verified, created_at, updated_at
+		) VALUES ($1, $2, $3, $4, $5, $6)`,
+		userID,
+		strings.ToLower(email),
+		primary,
+		verified,
+		now,
+		now,
+	)
+	if err != nil {
+		return fmt.Errorf("inserting email address for user %d: %w", userID, err)
+	}
+	return nil
+}

--- a/portaldb/usercreation.go
+++ b/portaldb/usercreation.go
@@ -89,7 +89,8 @@ func GetOccupationName(ctx context.Context, db *sql.DB, occupationID int) (strin
 
 // CreateUserWithEmail creates a user record and its associated email address
 // in a single transaction. Returns the new user's database ID.
-func CreateUserWithEmail(ctx context.Context, db *sql.DB, data CreateUserData, emailVerified bool) (int64, error) {
+// The email address is marked verified if and only if data.HasVerifiedEmail is true.
+func CreateUserWithEmail(ctx context.Context, db *sql.DB, data CreateUserData) (int64, error) {
 	tx, err := db.BeginTx(ctx, nil)
 	if err != nil {
 		return 0, fmt.Errorf("beginning transaction: %w", err)
@@ -101,7 +102,7 @@ func CreateUserWithEmail(ctx context.Context, db *sql.DB, data CreateUserData, e
 		return 0, err
 	}
 
-	if err := createEmailAddressTx(ctx, tx, userID, data.Email, true, emailVerified); err != nil {
+	if err := createEmailAddressTx(ctx, tx, userID, data.Email, true, data.HasVerifiedEmail); err != nil {
 		return 0, err
 	}
 


### PR DESCRIPTION
This is an adaptation of the automatic-user-creation branch that @slr71 created, plus some changes from me (mostly, establishing default values so we can successfully use it from a keycloak authenticator). That branch was based on the old Python version, so this reimplements it all in go.

I marked @slr71 as a co-author on the commit since this won't otherwise include mention of her work that I adapted.